### PR TITLE
Format candidate with hints about its type (strings, symbols, etc.)

### DIFF
--- a/src/MagicLiteralsSelector-Spec/MLSLiteralCandidatesPresenter.class.st
+++ b/src/MagicLiteralsSelector-Spec/MLSLiteralCandidatesPresenter.class.st
@@ -21,7 +21,7 @@ MLSLiteralCandidatesPresenter >> initializePresenters [
 	literalCandidatesTable := self newTable.
 	
 	literalCandidatesTable
-		addColumn: (SpStringTableColumn title: 'Literal value' evaluated: [ :literalCandidate | literalCandidate literalValue asString ]);
+		addColumn: (SpStringTableColumn title: 'Literal value' evaluated: [ :literalCandidate | literalCandidate "literalValue" asString ]);
 		addColumn:
 			((SpCheckBoxTableColumn title: 'Magic' evaluated: [ :literalCandidate | literalCandidate isMagic ])
 				onActivation: [ :literalCandidate | 

--- a/src/MagicLiteralsSelector-Spec/MLSLiteralCandidatesPresenter.class.st
+++ b/src/MagicLiteralsSelector-Spec/MLSLiteralCandidatesPresenter.class.st
@@ -21,7 +21,7 @@ MLSLiteralCandidatesPresenter >> initializePresenters [
 	literalCandidatesTable := self newTable.
 	
 	literalCandidatesTable
-		addColumn: (SpStringTableColumn title: 'Literal value' evaluated: [ :literalCandidate | literalCandidate "literalValue" asString ]);
+		addColumn: (SpStringTableColumn title: 'Literal value' evaluated: [ :literalCandidate | literalCandidate literalValue storeString ]);
 		addColumn:
 			((SpCheckBoxTableColumn title: 'Magic' evaluated: [ :literalCandidate | literalCandidate isMagic ])
 				onActivation: [ :literalCandidate | 

--- a/src/MagicLiteralsSelector-Tests/MLSLiteralCandidateTest.class.st
+++ b/src/MagicLiteralsSelector-Tests/MLSLiteralCandidateTest.class.st
@@ -64,7 +64,7 @@ MLSLiteralCandidateTest >> testPositionsInterval [
 	| literalCandidate |
 	literalCandidate := (MLSMethod compiledMethod: MLSMethodTest >> #sampleMethodWithLiterals) literalsCandidates detect: [ :l | l literalValue = 42 ].
 	
-	self assert: literalCandidate positionsInterval equals: (40 to: 41)
+	self assert: literalCandidate positionsInterval equals: (56 to: 57)
 ]
 
 { #category : #test }

--- a/src/MagicLiteralsSelector-Tests/MLSMethodTest.class.st
+++ b/src/MagicLiteralsSelector-Tests/MLSMethodTest.class.st
@@ -28,7 +28,7 @@ MLSMethodTest >> testLiteralsCandidates [
 		assertCollection: (method literalsCandidates collect: #literalValue)
 		includesAll: {42 . 1 . $a . 'A string' . #one}.
 	self
-		assertCollection: (method literalsCandidates collect: #asString)
+		assertCollection: (method literalsCandidates collect: [:c | c literalValue storeString])
 		includesAll: {'42' . '1' . '$a' . '''A string''' . '#one'}.
 	self
 		assert: (method literalsCandidates allSatisfy: [ :l | l status isUnknown ])

--- a/src/MagicLiteralsSelector-Tests/MLSMethodTest.class.st
+++ b/src/MagicLiteralsSelector-Tests/MLSMethodTest.class.st
@@ -9,20 +9,29 @@ Class {
 
 { #category : #'sample methods' }
 MLSMethodTest >> sampleMethodWithLiterals [
-	|x y |
+	|w x y z |
+	w := #one.
 	x := 42.
 	y := x + 1.
+	z := 'A string'.
+	
 	^ { x . y . $a }
 ]
 
 { #category : #test }
 MLSMethodTest >> testLiteralsCandidates [
 	| method |
-	method := MLSMethod compiledMethod: self class >> #sampleMethodWithLiterals.
-	
-	self assert: method literalsCandidates size equals: 3.
-	self assertCollection: (method literalsCandidates collect: #literalValue) includesAll: { 42 . 1 . $a }.
-	self assert: (method literalsCandidates allSatisfy: [ :l | l status isUnknown ])
+	method := MLSMethod
+		compiledMethod: self class >> #sampleMethodWithLiterals.
+	self assert: method literalsCandidates size equals: 5.
+	self
+		assertCollection: (method literalsCandidates collect: #literalValue)
+		includesAll: {42 . 1 . $a . 'A string' . #one}.
+	self
+		assertCollection: (method literalsCandidates collect: #asString)
+		includesAll: {'42' . '1' . '$a' . '''A string''' . '#one'}.
+	self
+		assert: (method literalsCandidates allSatisfy: [ :l | l status isUnknown ])
 ]
 
 { #category : #test }

--- a/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
+++ b/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
@@ -23,6 +23,22 @@ MLSLiteralCandidate class >> astNode: aLiteralASTNode [
 ]
 
 { #category : #accessing }
+MLSLiteralCandidate >> asString [
+	| theType |
+	theType := astNode value class.
+	theType = ByteSymbol
+		ifTrue: [ ^ '#' , astNode value asString ].
+	((theType = SmallInteger) | (theType = True) | (theType = False) | (theType = UndefinedObject ))
+		ifTrue: [ ^ astNode value asString ].
+	theType = ByteString
+		ifTrue: [ ^ '''' , astNode value asString , '''' ].
+	theType = Character
+		ifTrue: [ ^ '$' , astNode value asString ].
+	0 halt.
+	^ self astNode value asString
+]
+
+{ #category : #accessing }
 MLSLiteralCandidate >> astNode [
 	^ astNode
 ]

--- a/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
+++ b/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
@@ -26,6 +26,8 @@ MLSLiteralCandidate class >> astNode: aLiteralASTNode [
 MLSLiteralCandidate >> asString [
 	| theType |
 	theType := astNode value class.
+	theType = Character
+		ifTrue: [ ^ '$' , astNode value asString ].
 	(theType = ByteSymbol) | (theType = WideSymbol)  
 		ifTrue: [ ^ '#' , astNode value asString ].
 	(Magnitude allSubclasses includes: theType) | (theType = True)
@@ -33,8 +35,6 @@ MLSLiteralCandidate >> asString [
 		ifTrue: [ ^ astNode value asString ].
 	(theType = ByteString) | (theType = WideString)
 		ifTrue: [ ^ '''' , astNode value asString , '''' ].
-	theType = Character
-		ifTrue: [ ^ '$' , astNode value asString ].
 	0 halt.
 	^ self astNode value asString
 ]

--- a/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
+++ b/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
@@ -23,23 +23,6 @@ MLSLiteralCandidate class >> astNode: aLiteralASTNode [
 ]
 
 { #category : #accessing }
-MLSLiteralCandidate >> asString [
-	| theType |
-	theType := astNode value class.
-	theType = Character
-		ifTrue: [ ^ '$' , astNode value asString ].
-	(theType = ByteSymbol) | (theType = WideSymbol)  
-		ifTrue: [ ^ '#' , astNode value asString ].
-	(Magnitude allSubclasses includes: theType) | (theType = True)
-		| (theType = False) | (theType = UndefinedObject)
-		ifTrue: [ ^ astNode value asString ].
-	(theType = ByteString) | (theType = WideString)
-		ifTrue: [ ^ '''' , astNode value asString , '''' ].
-	0 halt.
-	^ self astNode value asString
-]
-
-{ #category : #accessing }
 MLSLiteralCandidate >> astNode [
 	^ astNode
 ]

--- a/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
+++ b/src/MagicLiteralsSelector/MLSLiteralCandidate.class.st
@@ -26,11 +26,12 @@ MLSLiteralCandidate class >> astNode: aLiteralASTNode [
 MLSLiteralCandidate >> asString [
 	| theType |
 	theType := astNode value class.
-	theType = ByteSymbol
+	(theType = ByteSymbol) | (theType = WideSymbol)  
 		ifTrue: [ ^ '#' , astNode value asString ].
-	((theType = SmallInteger) | (theType = True) | (theType = False) | (theType = UndefinedObject ))
+	(Magnitude allSubclasses includes: theType) | (theType = True)
+		| (theType = False) | (theType = UndefinedObject)
 		ifTrue: [ ^ astNode value asString ].
-	theType = ByteString
+	(theType = ByteString) | (theType = WideString)
 		ifTrue: [ ^ '''' , astNode value asString , '''' ].
 	theType = Character
 		ifTrue: [ ^ '$' , astNode value asString ].


### PR DESCRIPTION
The idea is to show `#symbol` if it's a symbol literal, `'Here is a string'` if it's a string, etc. I'm not sure my `asString` method is a great way to pull this off, but I think it would be faster for developers to confirm the literals if you can see this information. 